### PR TITLE
Add support for tvOS

### DIFF
--- a/YYWebImage.podspec
+++ b/YYWebImage.podspec
@@ -8,13 +8,15 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/ibireme/YYWebImage'
   s.platform     = :ios, '6.0'
   s.ios.deployment_target = '6.0'
+  s.tvos.deployment_target = "9.0"
   s.source       = { :git => 'https://github.com/ibireme/YYWebImage.git', :tag => s.version.to_s }
   
   s.requires_arc = true
   s.source_files = 'YYWebImage/*.{h,m}', 'YYWebImage/Categories/*.{h,m}'
   s.public_header_files = 'YYWebImage/*.{h}', 'YYWebImage/Categories/*.{h}'
   s.private_header_files = 'YYWebImage/Categories/_*.{h}'
-  s.frameworks = 'UIKit', 'CoreFoundation', 'QuartzCore', 'AssetsLibrary', 'ImageIO', 'Accelerate', 'MobileCoreServices'
+  s.tvos.frameworks = 'UIKit', 'CoreFoundation', 'QuartzCore', 'ImageIO', 'Accelerate', 'MobileCoreServices'
+  s.ios.frameworks = 'UIKit', 'CoreFoundation', 'QuartzCore', 'AssetsLibrary', 'ImageIO', 'Accelerate', 'MobileCoreServices'
   
   s.dependency 'YYImage'
   s.dependency 'YYCache'

--- a/YYWebImage/YYWebImageManager.m
+++ b/YYWebImage/YYWebImageManager.m
@@ -138,10 +138,12 @@ static UIApplication *_YYSharedApplication() {
     UIApplication *app = _YYSharedApplication();
     if (!app) return;
     
+#if TARGET_OS_IOS
     NSNumber *visiable = timer.userInfo;
     if (app.networkActivityIndicatorVisible != visiable.boolValue) {
         [app setNetworkActivityIndicatorVisible:visiable.boolValue];
     }
+#endif
     [timer invalidate];
 }
 


### PR DESCRIPTION
This is a minor change to make the YYWebImage library work with tvOS. It has been tested in production. 

The only necessary change to the code is to #if out the lines that display the network activity indicator when not running on iOS, as the there is no network activity indicator on tvOS.